### PR TITLE
Fix: Enable microphone access for macOS

### DIFF
--- a/frontend/flutter_application/macos/Runner/DebugProfile.entitlements
+++ b/frontend/flutter_application/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/frontend/flutter_application/macos/Runner/Info.plist
+++ b/frontend/flutter_application/macos/Runner/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>マイクを使用して音声を録音し、音楽解析機能を提供するためにマイクアクセスが必要です。</string>
 </dict>
 </plist>

--- a/frontend/flutter_application/macos/Runner/Release.entitlements
+++ b/frontend/flutter_application/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
- Add NSMicrophoneUsageDescription to Info.plist for macOS.
- Add com.apple.security.device.audio-input entitlement for macOS debug and release builds.

These changes allow the application to request microphone access on macOS, enabling audio recording functionality.