### PR TITLE
Add: 録音セクションに録音データ再生ボタンを追加

### DIFF
--- a/frontend/flutter_application/lib/main.dart
+++ b/frontend/flutter_application/lib/main.dart
@@ -921,16 +921,56 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ),
               const SizedBox(width: 8),
-              Text(
-                _recordingState == RecordingState.recording ? '録音中' : '録音開始',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: _recordingState == RecordingState.recording
-                      ? Colors.red
-                      : Colors.grey,
-                  fontWeight: FontWeight.w500,
+              Expanded(
+                child: Text(
+                  _recordingState == RecordingState.recording ? '録音中' : '録音開始',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: _recordingState == RecordingState.recording
+                        ? Colors.red
+                        : Colors.grey,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ),
+              // 録音データ再生ボタン
+              if (_audioFilePath != null) ...[
+                Container(
+                  width: 50,
+                  height: 50,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _isPlaying
+                        ? Colors.orange.shade100
+                        : Colors.green.shade100,
+                    border: Border.all(
+                      color: _isPlaying
+                          ? Colors.orange.shade300
+                          : Colors.green.shade300,
+                      width: 1.5,
+                    ),
+                  ),
+                  child: IconButton(
+                    icon: Icon(
+                      _isPlaying ? Icons.stop : Icons.play_arrow,
+                      size: 20,
+                      color: _isPlaying ? Colors.orange : Colors.green,
+                    ),
+                    onPressed: _recordingState == RecordingState.uploading
+                        ? null
+                        : _togglePlayback,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  _isPlaying ? '再生中' : '再生',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: _isPlaying ? Colors.orange : Colors.grey,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
             ],
           ),
           const SizedBox(height: 16),


### PR DESCRIPTION
録音ボタンの右端に録音した音声データを再生できる
ボタンを追加し、Web版とAndroid版の両方で利用可能に。

- 録音完了後に再生ボタンが表示
- 緑色の再生ボタン（再生中はオレンジ色）
- 既存の再生機能（_togglePlayback）を活用
- レスポンシブレイアウトでExpandedを使用
- アップロード中は再生ボタンも無効化

ユーザーが録音内容を即座に確認できるように。

🤖 Generated with [Claude Code](https://claude.ai/code)