### PR TITLE
fix: Remove duration info from demo section

### DIFF
--- a/story.md
+++ b/story.md
@@ -105,8 +105,6 @@ Session MUSEが単なる自動作曲ツールと一線を画すのが、この�
 |![image](screenshot/iOS/screenshot2.PNG)|![image](screenshot/iOS/screenshot3.PNG)|![image](screenshot/iOS/screenshot4.PNG)|![image](screenshot/iOS/screenshot5.PNG)|
 |:---:|:---:|:---:|:---:|
 
-**所要時間：約4分** (鼻歌アップロードから最終成果物まで)
-
 ## 4. 技術的挑戦と学び
 
 ### ハッカソンにおける挑戦


### PR DESCRIPTION
## Summary
- story.mdから所要時間の記載を削除

## Changes
- 「**所要時間：約4分** (鼻歌アップロードから最終成果物まで)」を削除
- 実際に測定していない情報を削除し、正確性を向上

🤖 Generated with [Claude Code](https://claude.ai/code)