### PR TITLE
feat: Add compressed demo video to story.md

### DIFF
--- a/story.md
+++ b/story.md
@@ -86,7 +86,8 @@ Session MUSEが単なる自動作曲ツールと一線を画すのが、この�
 -   **CI/CDとIaC**: Terraformでインフラをコード管理し、Cloud BuildとArtifact RegistryによるCI/CDパイプライン経由でCloud Runへ自動デプロイします。
 
 ## 3. デモンストレーション
-「「「「「「ここに動画を挿入」」」」」」
+
+![Session MUSE Demo](video/iOS_ScreenRecording_06-29-2025%2021-21-38_1.mp4)
 
 ### シナリオ：ユーザー「Takeshi」の創作セッション
 

--- a/story.md
+++ b/story.md
@@ -87,7 +87,7 @@ Session MUSEが単なる自動作曲ツールと一線を画すのが、この�
 
 ## 3. デモンストレーション
 
-![Session MUSE Demo](video/iOS_ScreenRecording_06-29-2025%2021-21-38_1.mp4)
+![Session MUSE Demo](video/demo_compressed.mp4)
 
 ### シナリオ：ユーザー「Takeshi」の創作セッション
 

--- a/story.md
+++ b/story.md
@@ -79,7 +79,7 @@ Session MUSEが単なる自動作曲ツールと一線を画すのが、この�
 ### システムアーキテクチャ
 このAIパイプラインは、以下のGoogle Cloudサービス群を組み合わせたイベント駆動型アーキテクチャで実現しています。
 
-![architecture](architecture.png)
+![image](architecture.png)
 
 -   **メイン処理**: Cloud Run上のFastAPIがリクエストを受け付け、LangGraphが上記パイプラインの一連の処理を非同期ワークフローとして管理します。
 -   **生成AI活用**: 楽曲のコアとなる「雰囲気の抽出」と「MusicXML生成」は、Vertex AI上のGeminiが担います。
@@ -87,7 +87,7 @@ Session MUSEが単なる自動作曲ツールと一線を画すのが、この�
 
 ## 3. デモンストレーション
 
-![Session MUSE Demo](video/demo_compressed.mp4)
+![video](video/demo_compressed.mp4)
 
 ### シナリオ：ユーザー「Takeshi」の創作セッション
 


### PR DESCRIPTION
## Summary
- story.mdに圧縮済みのデモ動画を追加

## Changes
- プレースホルダーテキストを実際のデモ動画に置き換え
- ffmpegでH.264圧縮・720pスケーリング（191MB → 8.4MB）
- Session MUSE iOSアプリの機能を実演

## Video Details
- Original size: 191MB
- Compressed size: 8.4MB
- Compression ratio: 95.6% reduction
- Format: H.264 MP4, 720p

🤖 Generated with [Claude Code](https://claude.ai/code)